### PR TITLE
Fix delay comment in api.php

### DIFF
--- a/api.php
+++ b/api.php
@@ -3,7 +3,7 @@ header('Content-Type: application/json');
 
 $delay = isset($_GET['delay']) ? (int)$_GET['delay'] : 0;
 
-// Clamp delay to max 10 seconds just for safety
+// Clamp delay to max 1 second just for safety
 $delay = max(0, min($delay, 1));
 
 // Simulate delay


### PR DESCRIPTION
## Summary
- fix delay clamp comment in `api.php` to reflect 1 second limit

## Testing
- `php -l api.php`


------
https://chatgpt.com/codex/tasks/task_e_687a6651fd4c8333b43c9ec75be11ff8