### PR TITLE
Improve select box focus handling

### DIFF
--- a/components/ui/selectBoxAttr.js
+++ b/components/ui/selectBoxAttr.js
@@ -180,6 +180,9 @@ export default class SelectBoxAttr extends HTMLElement {
     this._currentTabIndex = -1;
     const isOpen = this._dropdownEl.classList.toggle('opened');
     this._selectedEl.classList.toggle('active', isOpen);
+    if (isOpen) {
+      this.focus();
+    }
 
     if (isOpen && this.hasAttribute('searchable')) {
       if (!this._searchInput) {
@@ -239,6 +242,9 @@ export default class SelectBoxAttr extends HTMLElement {
         this._addMultiData(opt);
       }
       this._updateMultiDisplay();
+      if (this._searchInput) {
+        this._resetSearchInput();
+      }
     } else {
       this._selectSingle(opt);
       this._closeDropdown();


### PR DESCRIPTION
## Summary
- focus component after opening dropdown for keyboard events
- clear search field after selecting option in multi-select mode

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_687b7cc1f8e48333ac7d5e84b7b65654