### PR TITLE
Add page.js-style router with query parsing

### DIFF
--- a/assets/js/libs/page.mjs
+++ b/assets/js/libs/page.mjs
@@ -1,0 +1,34 @@
+export default function page(path, fn) {
+  if (typeof path === 'function') {
+    page.start(path);
+  } else {
+    page._routes.push({ path, fn });
+  }
+}
+
+page._routes = [];
+
+function dispatch(url) {
+  const urlObj = new URL(url, location.origin);
+  const path = urlObj.pathname;
+  const qs = urlObj.search.slice(1);
+  const query = {};
+  urlObj.searchParams.forEach((v, k) => {
+    query[k] = v;
+  });
+
+  const route = page._routes.find(r => r.path === path);
+  if (route) {
+    route.fn({ path, querystring: qs, query });
+  }
+}
+
+page.show = function (url) {
+  history.pushState({}, '', url);
+  dispatch(url);
+};
+
+page.start = function () {
+  window.addEventListener('popstate', () => dispatch(location.pathname + location.search));
+  dispatch(location.pathname + location.search);
+};

--- a/index.html
+++ b/index.html
@@ -19,6 +19,8 @@
         <script type="module" src="layout/sidebar.js"></script>
         <script type="module" src="layout/header-custom.js"></script>
         <script type="module" src="pages/atms-dashboard.js"></script>
+        <script type="module" src="pages/atm-analitic-geo.js"></script>
+        <script type="module" src="router.js"></script>
     </head>
 
     <body>

--- a/layout/header-custom.js
+++ b/layout/header-custom.js
@@ -4,6 +4,10 @@ import "../components/ui/selectBox.js";
 import locationTransformer from '../core/utils/location-transformer.js';
 
 class HeaderCustom extends DynamicElement {
+    static get observedAttributes() {
+        return ['page-title'];
+    }
+
     onConnected() {
         const state = store.getState();
         const regionsData = store.getState().regionsData;
@@ -30,13 +34,14 @@ class HeaderCustom extends DynamicElement {
     }
 
     template() {
+        const title = this.getAttribute('page-title') || 'Ակնարկ';
         return /* html */ `
             <div class="main-container">
                 <div class="row">
                     <div class="column sm-12">
                         <div class="header">
                             <div class="header__title">
-                                <div class="h1-font">Ակնարկ</div>
+                                <div class="h1-font">${title}</div>
                             </div>
                             <div class="header__right">
                                 <select-box id="city-selector" value="1" options='${JSON.stringify((this.cities))}'></select-box>

--- a/layout/sidebar.js
+++ b/layout/sidebar.js
@@ -1,6 +1,18 @@
 import { StaticElement } from "../core/static-element.js";
+import { navigate } from "../router.js";
 
 class SideBar extends StaticElement {
+    connectedCallback() {
+        super.connectedCallback();
+        const geoLink = this.querySelector('#geo');
+        if (geoLink) {
+            geoLink.addEventListener('click', e => {
+                e.preventDefault();
+                navigate('/geo');
+            });
+        }
+    }
+
     render() {
         return /* html */ `
             <aside class="sidebar">

--- a/pages/atm-analitic-geo.js
+++ b/pages/atm-analitic-geo.js
@@ -1,0 +1,18 @@
+import { DynamicElement } from '../core/dynamic-element.js';
+
+class AtmAnaliticGeo extends DynamicElement {
+    template() {
+        return /* html */ `
+            <div class="main-container">
+                <div class="row">
+                    <div class="column sm-12">
+                        <h2 class="h2-font">Աշխարհագրական վերլուծություն</h2>
+                    </div>
+                </div>
+            </div>
+        `;
+    }
+}
+
+customElements.define('atm-analitic-geo', AtmAnaliticGeo);
+

--- a/router.js
+++ b/router.js
@@ -1,0 +1,30 @@
+import page from './assets/js/libs/page.mjs';
+
+function renderRoute(component, title, query) {
+    const main = document.querySelector('main');
+    if (!main) return;
+    main.innerHTML = '';
+    const el = document.createElement(component);
+    el.routeQuery = query;
+    main.appendChild(el);
+
+    const header = document.querySelector('header-custom');
+    if (header) {
+        header.setAttribute('page-title', title);
+    }
+}
+
+page('/', ctx => {
+    renderRoute('atms-dashboard', 'Ակնարկ', ctx.query);
+});
+
+page('/geo', ctx => {
+    renderRoute('atm-analitic-geo', 'աշխարհագրական', ctx.query);
+});
+
+export function navigate(path) {
+    page.show(path);
+}
+
+page.start();
+


### PR DESCRIPTION
## Summary
- implement lightweight `page.mjs` mimicking page.js API
- refactor `router.js` to use `page` for route handling and query string support

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687e3a86f6b4833393d7b4b2f91934d4