### PR TITLE
Improve date handling components

### DIFF
--- a/components/dynamic/select-box-date.js
+++ b/components/dynamic/select-box-date.js
@@ -6,20 +6,33 @@ class SelectBoxDate extends DynamicElement {
   constructor() {
     super();
     this.selectEl = null;
+    this.startDate = null;
+    this.endDate = null;
+    this.period = "today";
   }
 
   static get observedAttributes() {
-    return ["value"];
+    return ["start-date", "end-date"];
   }
 
   onConnected() {
+    this._updateFromAttributes();
     this.render();
+  }
+
+  onAttributeChange(name, oldValue, newValue) {
+    if (name === "start-date" || name === "end-date") {
+      this._updateFromAttributes();
+    }
   }
 
   onAfterRender() {
     this.selectEl = this.$("select-box");
     if (this.selectEl) {
-      this.selectEl.value = this.getAttr("value", "today");
+      this.selectEl.value = this.period;
+      if (this.period === "custom") {
+        this._setCustomLabel(this.startDate, this.endDate);
+      }
     }
   }
 
@@ -31,26 +44,73 @@ class SelectBoxDate extends DynamicElement {
 
   onSelectChange(e) {
     const val = e.target.value;
-    this.setAttribute("value", val);
     if (val === "custom") {
       openDateRangePopup().then((range) => {
         if (range && range.startDate && range.endDate) {
-          this.dispatch("date-range-change", { ...range, period: val });
+          this.startDate = range.startDate;
+          this.endDate = range.endDate;
+          this.period = "custom";
+          this.setAttribute("start-date", this.startDate);
+          this.setAttribute("end-date", this.endDate);
+          this._setCustomLabel(this.startDate, this.endDate);
+          this.dispatch("date-range-change", {
+            startDate: this.startDate,
+            endDate: this.endDate,
+            period: "custom",
+          });
         }
       });
     } else {
       const range = resolvePeriodToDates(val);
       if (range) {
-        this.dispatch("date-range-change", { ...range, period: val });
+        this.startDate = range.startDate;
+        this.endDate = range.endDate;
+        this.period = val;
+        this.setAttribute("start-date", this.startDate);
+        this.setAttribute("end-date", this.endDate);
+        this.dispatch("date-range-change", {
+          startDate: this.startDate,
+          endDate: this.endDate,
+          period: val,
+        });
       }
     }
   }
 
+  _updateFromAttributes() {
+    this.startDate = this.getAttr("start-date") || null;
+    this.endDate = this.getAttr("end-date") || null;
+    this.period = this._datesToPeriod(this.startDate, this.endDate);
+  }
+
+  _datesToPeriod(start, end) {
+    if (!start || !end) return "today";
+    const today = new Date();
+    const todayStr = today.toISOString().slice(0, 10);
+    const weekEnd = new Date(today);
+    weekEnd.setDate(weekEnd.getDate() + 7);
+    const weekEndStr = weekEnd.toISOString().slice(0, 10);
+
+    if (start === todayStr && end === todayStr) {
+      return "today";
+    }
+    if (start === todayStr && end === weekEndStr) {
+      return "week";
+    }
+    return "custom";
+  }
+
+  _setCustomLabel(start, end) {
+    if (!this.selectEl) return;
+    const wrap = this.selectEl.querySelector(".combo-box-selected-wrap");
+    if (wrap) wrap.textContent = `${start} – ${end}`;
+    this.selectEl.value = "custom";
+  }
+
   template() {
-    const initial = this.getAttr("value", "today");
     return /* html */`
       <select-box
-        value="${initial}"
+        value="${this.period}"
         options='[
           {"value":"today","label":"Այսօր"},
           {"value":"week","label":"Այս շաբաթ"},


### PR DESCRIPTION
## Summary
- enhance `<select-box-date>` to synchronize start and end date attributes and compute period automatically
- simplify `<chart-component>` to rely on explicit start/end dates and handle `date-range-change` events accordingly

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688b30c2fbc08333962d50db045c9905