### PR TITLE
Implement grid.js component with server-side capabilities

### DIFF
--- a/components/dynamic/simpleGrid.js
+++ b/components/dynamic/simpleGrid.js
@@ -1,0 +1,312 @@
+// components/dynamic/simpleGrid.js
+import { DynamicElement } from "../../core/dynamic-element.js";
+import tableTransformer from "../../core/utils/table-transformer.js";
+
+// Lazy-load Grid.js once for all instances
+let gridJsModulePromise = null;
+function loadGridJsModule() {
+    if (!gridJsModulePromise) {
+        gridJsModulePromise = import("https://cdn.jsdelivr.net/npm/gridjs/dist/gridjs.module.js");
+    }
+    return gridJsModulePromise;
+}
+
+// Inject Grid.js CSS once
+let gridJsCssInjected = false;
+function ensureGridJsCss() {
+    if (gridJsCssInjected) return;
+    const id = "gridjs-css";
+    if (!document.getElementById(id)) {
+        const link = document.createElement("link");
+        link.id = id;
+        link.rel = "stylesheet";
+        link.href = "https://cdn.jsdelivr.net/npm/gridjs/dist/theme/mermaid.min.css";
+        document.head.appendChild(link);
+    }
+    gridJsCssInjected = true;
+}
+
+export class SimpleGrid extends DynamicElement {
+    constructor() {
+        super();
+        this.state = {
+            data: [],
+            columns: [],
+            loading: false,
+            error: false,
+            mode: "client", // client | server
+            perPage: 10,
+        };
+        this.grid = null;
+        this.latestServerUrl = null;
+    }
+
+    static get observedAttributes() {
+        return ["data-source", "columns", "clickable-columns", "mode", "per-page"]; 
+    }
+
+    async onConnected() {
+        ensureGridJsCss();
+        const url = this.getAttr("data-source");
+        if (url) await this.loadData();
+    }
+
+    async onAttributeChange(name, oldVal, newVal) {
+        if (oldVal === newVal) return;
+        if (name === "data-source") {
+            await this.loadData();
+            return;
+        }
+        if (name === "columns") {
+            const parsed = this.parseColumnsAttr();
+            if (parsed) this.setState({ columns: parsed });
+            return;
+        }
+        if (name === "mode") {
+            this.setState({ mode: this.getModeOption() });
+            return;
+        }
+        if (name === "per-page") {
+            this.setState({ perPage: this.getPerPageOption() });
+            return;
+        }
+    }
+
+    parseColumnsAttr() {
+        try {
+            const raw = this.getAttr("columns");
+            return raw ? JSON.parse(raw) : [];
+        } catch (e) {
+            console.warn("Invalid columns attribute JSON", e);
+            return [];
+        }
+    }
+
+    parseClickableColumnsAttr() {
+        try {
+            const raw = this.getAttr("clickable-columns");
+            return raw ? JSON.parse(raw) : [];
+        } catch (e) {
+            console.warn("Invalid clickable-columns attribute JSON", e);
+            return [];
+        }
+    }
+
+    getModeOption() {
+        const raw = (this.getAttr("mode") || "client").toLowerCase();
+        return raw === "server" ? "server" : "client";
+    }
+
+    getPerPageOption() {
+        const raw = this.getAttr("per-page");
+        const val = parseInt(raw, 10);
+        return isNaN(val) ? 10 : val;
+    }
+
+    async loadData() {
+        const mode = this.getModeOption();
+        this.setState({ loading: true, error: false, mode, perPage: this.getPerPageOption() });
+
+        const url = this.getAttr("data-source");
+        if (!url) {
+            this.setState({ loading: false, error: true });
+            return;
+        }
+
+        if (mode === "client") {
+            try {
+                const raw = await this.fetchData(url);
+                const transformed = tableTransformer.transformFaultTableData(raw) || [];
+                const definedColumns = this.parseColumnsAttr();
+                const columns = definedColumns.length ? definedColumns : Object.keys(transformed[0] || {});
+                this.setState({ data: transformed, columns, loading: false });
+            } catch (err) {
+                console.warn("Failed to load or transform grid data", err);
+                this.setState({ loading: false, error: true });
+            }
+        } else {
+            // server mode defers data loading to Grid.js server config
+            try {
+                // Probe once to derive columns if not provided
+                const definedColumns = this.parseColumnsAttr();
+                let columns = definedColumns;
+                if (!columns.length) {
+                    try {
+                        const raw = await this.fetchData(url);
+                        const transformed = tableTransformer.transformFaultTableData(raw) || [];
+                        columns = Object.keys(transformed[0] || {});
+                    } catch (_) {
+                        // ignore probe error; grid server mode may still work
+                    }
+                }
+                this.setState({ columns, loading: false });
+            } catch (err) {
+                console.warn("Failed to initialize server grid", err);
+                this.setState({ loading: false, error: true });
+            }
+        }
+    }
+
+    onAfterRender() {
+        // Destroy old grid if exists to avoid duplicates
+        if (this.grid && typeof this.grid.destroy === "function") {
+            try { this.grid.destroy(); } catch {}
+            this.grid = null;
+        }
+
+        if (this.state.error) return;
+        if (!this.state.columns.length) return;
+
+        const mountPoint = this.$(".grid-container");
+        if (!mountPoint) return;
+
+        loadGridJsModule().then((module) => {
+            const { Grid, h } = module;
+
+            const clickableColumns = this.parseClickableColumnsAttr();
+            const clickableSet = new Set(clickableColumns);
+
+            const gridColumns = this.state.columns.map((colName, colIndex) => {
+                // Use formatter only for clickable columns
+                if (!clickableSet.has(colName)) return { name: colName };
+                return {
+                    name: colName,
+                    formatter: (cell, row) => {
+                        // Wrap in a clickable span; Grid.js "row" includes cell data array
+                        return h(
+                            "span",
+                            {
+                                className: "clickable",
+                                onclick: () => {
+                                    const rowObj = this.rowArrayToObject(row.cells.map(c => c.data));
+                                    this.dispatch("cell-click", {
+                                        column: colName,
+                                        cellValue: rowObj[colName],
+                                        rowData: rowObj,
+                                    });
+                                }
+                            },
+                            cell ?? ""
+                        );
+                    }
+                };
+            });
+
+            const baseConfig = {
+                columns: gridColumns,
+                pagination: {
+                    enabled: true,
+                    limit: this.state.perPage,
+                },
+                sort: true,
+                search: false,
+                className: {
+                    td: "gridjs-td",
+                    th: "gridjs-th"
+                }
+            };
+
+            const mode = this.state.mode;
+            const endpoint = this.getAttr("data-source");
+
+            if (mode === "client") {
+                const dataArray = this.state.data.map(row => this.state.columns.map(c => row[c] ?? ""));
+                this.grid = new Grid({
+                    ...baseConfig,
+                    data: dataArray
+                });
+            } else {
+                // Server mode
+                this.latestServerUrl = endpoint;
+                this.grid = new Grid({
+                    ...baseConfig,
+                    server: {
+                        url: endpoint,
+                        then: (resp) => {
+                            // Expect API similar to existing transformer structures.
+                            // We reuse transformer for mapping shape. If the server already returns sliced data,
+                            // use it directly; otherwise, transform known formats.
+                            let transformed;
+                            if (resp && resp.data) {
+                                // Try transform helper
+                                try {
+                                    const maybe = tableTransformer.transformFaultTableData({ data: resp.data });
+                                    transformed = Array.isArray(maybe) ? maybe : resp.data;
+                                } catch (_) {
+                                    transformed = resp.data;
+                                }
+                            } else {
+                                try {
+                                    const maybe = tableTransformer.transformFaultTableData(resp) || [];
+                                    transformed = maybe;
+                                } catch (_) {
+                                    transformed = Array.isArray(resp) ? resp : [];
+                                }
+                            }
+                            return transformed.map(item => this.state.columns.map(c => item?.[c] ?? ""));
+                        },
+                        total: (resp) => {
+                            // Try common fields for total records
+                            if (typeof resp?.total === "number") return resp.total;
+                            if (typeof resp?.data?.total === "number") return resp.data.total;
+                            if (Array.isArray(resp?.data)) return resp.data.length;
+                            if (Array.isArray(resp)) return resp.length;
+                            return 0;
+                        }
+                    },
+                    pagination: {
+                        enabled: true,
+                        limit: this.state.perPage,
+                        server: {
+                            url: (prev, page, limit) => {
+                                const offset = page * limit;
+                                const join = prev.includes("?") ? "&" : "?";
+                                return `${prev}${join}limit=${limit}&offset=${offset}`;
+                            }
+                        }
+                    },
+                    sort: {
+                        multiColumn: false,
+                        server: {
+                            url: (prev, columns) => {
+                                if (!columns?.length) return prev;
+                                const col = columns[0];
+                                const dir = col.direction === 1 ? "asc" : "desc";
+                                const colName = this.state.columns[col.index];
+                                const join = prev.includes("?") ? "&" : "?";
+                                return `${prev}${join}sort=${encodeURIComponent(colName)}&order=${dir}`;
+                            }
+                        }
+                    }
+                });
+            }
+
+            this.grid.render(mountPoint);
+        });
+    }
+
+    rowArrayToObject(rowArray) {
+        const obj = {};
+        for (let i = 0; i < this.state.columns.length; i++) {
+            obj[this.state.columns[i]] = rowArray[i];
+        }
+        return obj;
+    }
+
+    template() {
+        if (this.state.error) {
+            return `<div class="error">Failed to load grid data.</div>`;
+        }
+
+        if (this.state.loading) {
+            return `<div class="loading">Loading grid…</div>`;
+        }
+
+        return /* html */ `
+      <div class="grid-container"></div>
+    `;
+    }
+}
+
+customElements.define("simple-grid", SimpleGrid);
+

--- a/pages/atm-failures.js
+++ b/pages/atm-failures.js
@@ -2,7 +2,7 @@ import { DynamicElement } from "../core/dynamic-element.js";
 import "../components/dynamic/chartComponent.js";
 import "../components/dynamic/infoCard.js";
 import "../components/ui/customTab.js";
-import "../components/dynamic/simpleTable.js";
+import "../components/dynamic/simpleGrid.js";
 import "../components/dynamic/select-box.js";
 import "../components/dynamic/select-box-date.js";
 
@@ -12,7 +12,7 @@ class AtmFailures extends DynamicElement {
     }
 
     addEventListeners() {
-        this.$("simple-table")?.addEventListener("cell-click", (e) => {
+        this.$("simple-grid")?.addEventListener("cell-click", (e) => {
             const { column, cellValue, rowData } = e.detail;
             // Open popup or do something with the data
             console.log("cellValue", column, cellValue, rowData);
@@ -31,11 +31,13 @@ class AtmFailures extends DynamicElement {
                                 end-date="${this.getAttr("end-date")}"
                             ></select-box-date>
                         </div>  
-                        <simple-table
+                        <simple-grid
                             data-source="/device-faults/summary?startDate=2025-06-01"
                             columns='["atm_and_address", "total_faults", "faults_summary"]'
-                            clickable-columns='["faults_summary"]'>
-                        </simple-table>
+                            clickable-columns='["faults_summary"]'
+                            mode="client"
+                            per-page="10">
+                        </simple-grid>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
Introduce `simpleGrid` component using Grid.js to replace `simpleTable` in `atm-failures`, adding server-side pagination and sorting capabilities.

---
<a href="https://cursor.com/background-agent?bcId=bc-a75684e3-e323-4774-8ff9-3fe5aa200836">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a75684e3-e323-4774-8ff9-3fe5aa200836">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

