### PR TITLE
Implement server-side pagination for simpleGrid

### DIFF
--- a/components/dynamic/simpleGrid.js
+++ b/components/dynamic/simpleGrid.js
@@ -247,6 +247,7 @@ export class SimpleGrid extends DynamicElement {
                         },
                         total: (resp) => {
                             // Try common fields for total records
+                            if (typeof resp?.data?.total_count === "number") return resp.data.total_count;
                             if (typeof resp?.total === "number") return resp.total;
                             if (typeof resp?.data?.total === "number") return resp.data.total;
                             if (Array.isArray(resp?.data)) return resp.data.length;
@@ -259,9 +260,9 @@ export class SimpleGrid extends DynamicElement {
                         limit: this.state.perPage,
                         server: {
                             url: (prev, page, limit) => {
-                                const offset = page * limit;
                                 const join = prev.includes("?") ? "&" : "?";
-                                return `${prev}${join}limit=${limit}&offset=${offset}`;
+                                // API expects pageSize and 1-based pageNumber
+                                return `${prev}${join}pageSize=${limit}&pageNumber=${page + 1}`;
                             }
                         }
                     },

--- a/pages/journal.js
+++ b/pages/journal.js
@@ -95,7 +95,7 @@
 
 import { DynamicElement } from "../core/dynamic-element.js";
 import "../components/dynamic/list-view.js";
-import "../components/dynamic/simpleTable.js";  // ADD THIS LINE
+import "../components/dynamic/simpleGrid.js";  // switch to simple grid
 import encode from "../assets/js/utils/encode.js";
 
 class JournalPage extends DynamicElement {
@@ -137,13 +137,13 @@ console.log('template journal');
             <div class="row">
                 <div class="column sm-12">
                     <div class="container">
-                        <simple-table
+                        <simple-grid
                             data-source="/journal/events-journal"
                             columns='["server_date", "code", "card_number", "event_description"]'
                             clickable-columns='["code"]'
-                            pagination-mode="server"
+                            mode="server"
                             per-page="10">
-                        </simple-table>
+                        </simple-grid>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
Enable server-side pagination for Journal Events by updating `simpleGrid` to use `pageSize`/`pageNumber` and `data.total_count`, and switching `journal.js` to `simple-grid`.

---
<a href="https://cursor.com/background-agent?bcId=bc-47826ce2-468a-4f5d-a1ff-57eb9e5b7e32">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-47826ce2-468a-4f5d-a1ff-57eb9e5b7e32">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

